### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk --update --no-cache add \
     g++ \
     make \
     musl-dev \
-    libffi-dev
+    libffi-dev \
+    zlib-dev
 COPY Gemfile /build/
 COPY package.json /build/
 COPY bin/setup /build/bin/setup


### PR DESCRIPTION
Nokogiri failed to build unless it had the zlib package installed.